### PR TITLE
LinkingデバイスプラグインのTemperatureProfileの修正

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceLinking/dConnectDeviceLinking/Classes/beacon/profile/DPLinkingBeaconTemperatureProfile.m
+++ b/dConnectDevicePlugin/dConnectDeviceLinking/dConnectDeviceLinking/Classes/beacon/profile/DPLinkingBeaconTemperatureProfile.m
@@ -41,7 +41,7 @@
     float temp = beacon.temperatureData.value;
     int type = [request integerForKey:DCMTemperatureProfileParamType];
     if (type == DCMTemperatureProfileEnumCelsiusFahrenheit) {
-        temp = [DCMTemperatureProfile convertFahrenheitToCelsius:temp];
+        temp = [DCMTemperatureProfile convertCelsiusToFahrenheit:temp];
     } else {
         // 1,2以外は摂氏とする。
         type = DCMTemperatureProfileEnumCelsius;


### PR DESCRIPTION
# 修正内容
* Linkingデバイスプラグインの気温取得において、摂氏から華氏への計算が間違っていたので修正