### PR TITLE
IRKitデバイスプラグインのiPad用設定画面のレイアウト調整

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceIRKit/dConnectDeviceIRKit/Resources/Base.lproj/Storyboard_iPad.storyboard
+++ b/dConnectDevicePlugin/dConnectDeviceIRKit/dConnectDeviceIRKit/Resources/Base.lproj/Storyboard_iPad.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="vA2-Yc-ReR">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="vA2-Yc-ReR">
     <device id="ipad9_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -43,18 +43,19 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </tableView>
-                            <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qNy-SW-3fT">
-                                <rect key="frame" x="-109" y="980" width="877" height="44"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qNy-SW-3fT">
+                                <rect key="frame" x="0.0" y="980" width="768" height="44"/>
                                 <items>
                                     <barButtonItem style="plain" systemItem="flexibleSpace" id="LNA-po-koG"/>
                                     <barButtonItem title="追加" id="D0e-py-JHL">
+                                        <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <connections>
                                             <action selector="addVirtualDevice:" destination="WBJ-9Q-AJJ" id="PLh-S1-D5v"/>
                                         </connections>
                                     </barButtonItem>
                                     <barButtonItem style="plain" systemItem="flexibleSpace" id="qCi-nb-FhV"/>
                                     <barButtonItem title="削除" id="bkk-lv-flc">
+                                        <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <connections>
                                             <action selector="deleteVirtualDevice:" destination="WBJ-9Q-AJJ" id="z9z-Er-Fm5"/>
                                         </connections>
@@ -64,6 +65,11 @@
                             </toolbar>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="qNy-SW-3fT" firstAttribute="leading" secondItem="7S0-OM-lMF" secondAttribute="leading" id="C8M-bV-mn4"/>
+                            <constraint firstItem="qNy-SW-3fT" firstAttribute="bottom" secondItem="7S0-OM-lMF" secondAttribute="bottomMargin" id="ZLu-sW-ozu"/>
+                            <constraint firstAttribute="trailing" secondItem="qNy-SW-3fT" secondAttribute="trailing" id="tOD-8S-NpM"/>
+                        </constraints>
                     </view>
                     <toolbarItems/>
                     <navigationItem key="navigationItem" id="Wpx-LF-uNS"/>
@@ -93,8 +99,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="9Zg-nz-AQv">
-                                <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="9Zg-nz-AQv">
+                                <rect key="frame" x="4" y="0.0" width="760" height="1024"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </tableView>
                         </subviews>


### PR DESCRIPTION
# 動作確認
1.  IRKitをiPadに認識させる。
2. IRKitのサービス一覧画面から認識したIRKitを選択する。
3. 仮想デバイスプラグイン一覧のタブの色がナビゲーションバーと同じであること。