### PR TITLE
DeviceConnect SDKを CocoaPodsの Framework形態で利用した場合に、DCBundle() が nilを返してしまう問題を修正

### DIFF
--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/DConnectConst.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/DConnectConst.h
@@ -11,7 +11,7 @@
 #define DC_SYNC_END }
 
 #define DCBundle() \
-[NSBundle bundleWithPath:[[NSBundle mainBundle] pathForResource:@"DConnectSDK_resources" ofType:@"bundle"]]
+[NSBundle bundleWithPath:[[NSBundle bundleForClass:NSClassFromString(@"DConnectManager")] pathForResource:@"DConnectSDK_resources" ofType:@"bundle"]]
 
 #define DCLocalizedString(bundle, key) \
 [bundle localizedStringForKey:key value:@"" table:nil]


### PR DESCRIPTION
- Make DCBundle() macro possible to search the Framework's bundle when DConnextSDK was built as Framework.