### PR TITLE
DConnectDevicePluginクラスのサブクラスを Swiftで実装することができない問題に対処。

### DIFF
--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/DConnectDevicePlugin.m
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/DConnectDevicePlugin.m
@@ -41,7 +41,9 @@
 - (id) initWithObject: (id) object {
     self = [super init];
     if (self) {
-        
+        if (object == nil) {
+            object = self;
+        }
         // デバイスプラグインデータ設定
         CipherSignatureProc *md5Proc = [CipherSignatureFactory getInstance: CIPHER_SIGNATURE_KIND_MD5];
         self.useLocalOAuth = YES;

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectDevicePlugin.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectDevicePlugin.h
@@ -83,7 +83,7 @@
  @brief 任意のオブジェクトを指定してServiceManagerを初期化する。
  オブジェクトはDConnectDevicePluginもしくはDConnectManagerのインスタンスでなければならない。
  
- @param[in] object DConnectDevicePluginもしくはDConnectManagerのインスタンス
+ @param[in] object DConnectDevicePluginもしくはDConnectManagerのインスタンス。nilを渡した場合はこのプラグインインスタンス自身(self)が使われる。
  
  @retval ServiceManagerインスタンス。
  */


### PR DESCRIPTION
DConnectDevicePluginクラスは initWithObject: を使って初期化を行うことになっていますが、多くのケースで objectには selfを渡す必要があると理解しています。[プラグインマニュアル](https://github.com/DeviceConnect/DeviceConnect-iOS/wiki/DevicePluginManual-20) のサンプルコードにも以下のように書かれています。

```
@implementation MyPlugin

- (instancetype) init {
    self = [super initWithObject: self];
    if (self) {
```

一方、プラグインを Swiftで実装する場合、`super.init(object: self)` という呼び出しが必要となりますが、
Swiftでは super.init() の呼び出しが終わるまで initの中で self は使えないという制限があり、super.init(object: self) という呼び出しは不正とされています。

実際には、Swift4 (Xcode 9.2)の環境ではエラーにはなっておりませんでしたが、先日リリースされた Swift 4.1 (Xcode 9.3) では、

```
'self' used before 'super.init' call
```
というエラーになり、コンパイルできません。

### スクリーンショット
![2018-04-06 9 47 11](https://user-images.githubusercontent.com/5236338/38398994-8b119ad2-3982-11e8-9f8c-d3b66bb34caf.png)

## 修正内容

そのため、本修正では DConnectDevicePluginクラスの initWithObject: の仕様を変更し、objectとして nilを渡せるようにし、その場合はデフォルトの動作として自分自身(self)を使って初期化するように変更しました。

親クラスのイニシャライザに selfを渡して初期化することになった経緯など、背景事情が理解しきれていない部分もあるのですが、問題ないようでしたらマージしていただけると助かります。